### PR TITLE
Changing the cwd of bower does not effect target directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ module.exports = function (opts, cmdArguments) {
 			stream.end();
 		})
 		.on('end', function() {
-			var walker = walk.walk(dir);
+			var baseDir = path.join(opts.cwd, dir);
+			var walker = walk.walk(baseDir);
 			walker.on("errors", function(root, stats, next) {
 				stream.emit('error', new gutil.PluginError('gulp-bower', stats.error));
 				next();
@@ -75,7 +76,7 @@ module.exports = function (opts, cmdArguments) {
 						stream.emit('error', new gutil.PluginError('gulp-bower', error));
 					else
 						stream.write(new gutil.File({
-							path: path.relative(dir, filePath),
+							path: path.relative(baseDir, filePath),
 							contents: data
 						}));
 


### PR DESCRIPTION
This fix solves problems when using gulp in another cwd.

Example:

```
gulp --cwd app bower
```

```js
gulp.task('bower', function () {
  return bower({ cwd: '..' }).pipe('build/bower_components');
});
```