### PR TITLE
loosen dependency on gulp-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"bower": "^1.3.12",
-		"gulp-util": "3.0.1",
+		"gulp-util": "^3.0.1",
 		"through2": "0.6.2",
 		"walk": "2.3.3"
 	},


### PR DESCRIPTION
gulp requires now gulp-util 3.0.7.
It is unlikely to break this package to upgrade patch or minor version
We should be able to loosen the dependency on gulp-util.
tested locally, ok.