### PR TITLE
Add verbosity options, prompting, .bowerrc handling, tests and CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+bower_components/
+bower.json
+coverage/
 /node_modules
 /*.log
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+install: npm install
+script: npm test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gulp-bower
 > Install Bower packages.
 
+[![Build Status](https://travis-ci.org/Crevil/gulp-bower.svg?branch=master)](https://travis-ci.org/Crevil/gulp-bower) [![codecov.io](https://codecov.io/github/Crevil/gulp-bower/coverage.svg?branch=master)](https://codecov.io/github/Crevil/gulp-bower?branch=master)
+
 This task is designed for gulp 3.
 
 ## Usage
@@ -52,6 +54,7 @@ By default `gulp-bower` runs `install` command for Bower.
 Using `cmd` property, you can specify the custom command. (e.g. `update`)
 
 ```javascript
+var gulp = require('gulp');
 var bower = require('gulp-bower');
 
 gulp.task('bower', function() {
@@ -59,7 +62,19 @@ gulp.task('bower', function() {
 });
 ```
 
+## API
+### `bower(directory)`
+* **directory** - `string` Install directory, see **opts.directory** below.
 
+### `bower(opts)`
+* **opts.cmd** - `string` bower command. Default: `install` 
+* **opts.cwd** - `string` Current working directory. Default: `process.cwd()`
+* **opts.directory** - `string` Install directory. Default: From `.bowerrc` or `bower_components`
+* **opts.interactive** - `boolean` Enable prompting on version conflicts. Default: `false`
+* **opts.verbosity** - `number` Set verbosity level. Default: `2`
+  * **0** - No output
+  * **1** - Error output
+  * **2** - Info
 
 ## Changelog
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,37 @@
 /* jshint node:true */
-
 'use strict';
 
 var gulp = require('gulp');
 var jshint = require('gulp-jshint');
+var mocha = require('gulp-mocha');
+var istanbul = require('gulp-istanbul');
+var codecov = require('gulp-codecov.io');
 
-gulp.task('lint', function() {
-	return gulp.src('index.js')
-		.pipe(jshint())
-		.pipe(jshint.reporter('default'))
+gulp.task('lint', function () {
+    return gulp.src(['index.js', 'tests/test.js'])
+        .pipe(jshint())
+        .pipe(jshint.reporter('default'))
+});
+
+gulp.task('coverage-setup', function () {
+    return gulp.src('index.js')
+        .pipe(istanbul())
+        .pipe(istanbul.hookRequire());
+});
+
+gulp.task('test', ['coverage-setup'], function () {
+    return gulp.src('tests/test.js', { read: false })
+        .pipe(mocha({ reporter: 'spec', timeout: 15000 }))
+        .pipe(istanbul.writeReports());
+});
+
+gulp.task('post-coverage', ['test'], function () {
+    return gulp.src('./coverage/lcov.info')
+        .pipe(codecov());
+});
+
+gulp.task('watch-test', function () {
+    gulp.watch(['index.js', 'tests/test.js'], ['test']);
 });
 
 gulp.task('default', ['lint']);

--- a/index.js
+++ b/index.js
@@ -1,120 +1,245 @@
+/* global process */
 var bower = require('bower');
 var fs = require('fs');
 var gutil = require('gulp-util');
 var path = require('path');
 var through = require('through2');
 var walk = require('walk');
+var inquirer = require('inquirer');
 
-var toString = {}.toString;
+var toString = {}.toString,
+    enablePrompt,
+    cmd;
 
-module.exports = function (opts, cmdArguments) {
+var PLUGIN_NAME = 'gulp-bower',
+    DEFAULT_VERBOSITY = 2,
+    DEFAULT_CMD = 'install',
+    DEFAULT_DIRECTORY = './bower_components',
+    DEFAULT_INTERACTIVE = false;
 
-	var stream = through.obj(function(file, enc, callback) {
-		this.push(file);
-		callback();
-	});
-
-	if (toString.call(opts) === '[object String]') {
-		opts = {
-			directory: opts
-		};
-	}
-
-	opts = opts || {};
-	opts.cwd = opts.cwd || process.cwd();
-
-	if (!opts.directory) {
-		var bowerrc = path.join(opts.cwd, '.bowerrc');
-		if (fs.existsSync(bowerrc)) {
-			var bower_config = JSON.parse(fs.readFileSync(bowerrc));
-			opts.directory = bower_config.directory;
-		}
-		opts.directory = opts.directory || './bower_components';
-	}
-
-	var dir = opts.directory;
-	gutil.log("Using cwd: ", opts.cwd);
-	gutil.log("Using bower dir: ", dir);
-
-	var cmd = opts.cmd || 'install';
-	delete(opts.cmd);
-
-	if (toString.call(cmdArguments) !== '[object Array]') {
-		cmdArguments = [];
-	}
-	if (toString.call(cmdArguments[0]) !== '[object Array]') {
-		cmdArguments[0] = [];
-	}
-	cmdArguments[1] = cmdArguments[1] || {};
-	cmdArguments[2] = opts;
-
-
-	// bower has some commands that are provided in a nested object structure, e.g. `bower cache clean`.
-	var bowerCommand;
-
-	// clean up the command given, to avoid unnecessary errors
-	cmd = cmd.trim();
-
-	var nestedCommand = cmd.split(' ');
-
-	if (nestedCommand.length > 1) {
-		// To enable that kind of nested commands, we try to resolve those commands, before passing them to bower.
-		for (var commandPos = 0; commandPos < nestedCommand.length; commandPos++) {
-			if (bowerCommand) {
-				// when the root command is already there, walk into the depth.
-				bowerCommand = bowerCommand[nestedCommand[commandPos]];
-			} else {
-				// the first time we look for the "root" commands available in bower
-				bowerCommand = bower.commands[nestedCommand[commandPos]];
-			}
-		}
-
-		// try to give a good error description to the user when a bad command was passed
-		if (bowerCommand === undefined) {
-			throw("The command " + cmd + " is not available in the bower commands");
-		}
-	} else {
-		// if the command isn't nested, just go ahead as usual
-		bowerCommand = bower.commands[cmd];
-	}
-
-	bowerCommand.apply(bower.commands, cmdArguments)
-		.on('log', function(result) {
-			gutil.log(['bower', gutil.colors.cyan(result.id), result.message].join(' '));
-		})
-		.on('error', function(error) {
-			stream.emit('error', new gutil.PluginError('gulp-bower', error));
-			stream.end();
-		})
-		.on('end', function() {
-			var baseDir = path.join(opts.cwd, dir);
-			var walker = walk.walk(baseDir);
-			walker.on("errors", function(root, stats, next) {
-				stream.emit('error', new gutil.PluginError('gulp-bower', stats.error));
-				next();
-			});
-			walker.on("directory", function(root, stats, next) {
-				next();
-			});
-			walker.on("file", function(root, stats, next) {
-				var filePath = path.resolve(root, stats.name);
-
-				fs.readFile(filePath, function(error, data) {
-					if (error)
-						stream.emit('error', new gutil.PluginError('gulp-bower', error));
-					else
-						stream.write(new gutil.File({
-							path: path.relative(baseDir, filePath),
-							contents: data
-						}));
-
-					next();
-				});
-			});
-			walker.on("end", function() {
-				stream.end();
-			});
-		});
-
-	return stream;
+/*
+ * Verbosity levels:
+ * 0: No output
+ * 1: Error output
+ * 2: All output
+ */
+var log = {
+    verbosity: DEFAULT_VERBOSITY,
+    info: function (s) {
+        if (this.verbosity > 1) {
+            log.output(s);
+        }
+    },
+    error: function (s) {
+        if (this.verbosity > 0) {
+            log.output(gutil.colors.red(s));
+        }
+    },
+    output: function (s) {
+        gutil.log(s);
+    }
 };
+
+/**
+ * Gulp bower plugin
+ *
+ * @param {(object | string)} opts options object or directory string, see opts.directory
+ * @param {string} opts.cmd bower command (default: install)
+ * @param {string} opts.cwd current working directory (default: process.cwd())
+ * @param {string} opts.directory bower components directory (default: .bowerrc config or 'bower_components')
+ * @param {boolean} opts.interactive enable prompting from bower (default: false)
+ * @param {number} opts.verbosity set logging level from 0 (no output) to 2 for info (default: 2)
+ */
+function gulpBower(opts, cmdArguments) {
+    opts = parseOptions(opts);
+
+    log.info('Using cwd: ' + opts.cwd);
+    log.info('Using bower dir: ' + opts.directory);
+
+    cmdArguments = createCmdArguments(cmdArguments, opts);
+    var bowerCommand = getBowerCommand(cmd);
+
+    var stream = through.obj(function (file, enc, callback) {
+        this.push(file);
+        callback();
+    });
+
+    bowerCommand.apply(bower.commands, cmdArguments)
+        .on('log', function (result) {
+            log.info(['bower', gutil.colors.cyan(result.id), result.message].join(' '));
+        })
+        .on('prompt', function (prompts, callback) {
+            if (enablePrompt === true) {
+                inquirer.prompt(prompts, callback);
+            } else {
+                var error = 'Can\'t resolve suitable dependency version.';
+                log.error(error);
+                log.error('Set option { interactive: true } to select.');
+                throw new gutil.PluginError(PLUGIN_NAME, error);
+            }
+        })
+        .on('error', function (error) {
+            stream.emit('error', new gutil.PluginError(PLUGIN_NAME, error));
+            stream.emit('end');
+        })
+        .on('end', function () {
+            writeStreamToFs(opts, stream);
+        });
+
+    return stream;
+}
+
+/**
+ * Parse plugin options
+ *
+ * @param {object | string} opts options object or directory string
+ */
+function parseOptions(opts) {
+    opts = opts || {};
+    if (toString.call(opts) === '[object String]') {
+        opts = {
+            directory: opts
+        };
+    }
+
+    opts.cwd = opts.cwd || process.cwd();
+
+    log.verbosity = toString.call(opts.verbosity) === '[object Number]' ? opts.verbosity : DEFAULT_VERBOSITY;
+    delete (opts.verbosity);
+
+    cmd = opts.cmd || DEFAULT_CMD;
+    delete (opts.cmd);
+
+    // enable bower prompting but ignore the actual prompt if interactive == false
+    enablePrompt = opts.interactive || DEFAULT_INTERACTIVE;
+    opts.interactive = true;
+
+    if (!opts.directory) {
+        opts.directory = getDirectoryFromBowerRc(opts.cwd) || DEFAULT_DIRECTORY;
+    }
+
+    return opts;
+}
+
+/**
+ * Detect .bowerrc file and read directory from file
+ *
+ * @param {string} cwd current working directory
+ * @returns {string} found directory or empty string
+ */
+function getDirectoryFromBowerRc(cwd) {
+    var bowerrc = path.join(cwd, '.bowerrc');
+
+    if (!fs.existsSync(bowerrc)) {
+        return '';
+    }
+
+    var bower_config = {};
+    try {
+        bower_config = JSON.parse(fs.readFileSync(bowerrc));
+    } catch (err) {
+        return '';
+    }
+
+    return bower_config.directory;
+}
+
+/**
+ * Create command arguments
+ *
+ * @param {any} cmdArguments
+ * @param {object} opts options object
+ */
+function createCmdArguments(cmdArguments, opts) {
+    if (toString.call(cmdArguments) !== '[object Array]') {
+        cmdArguments = [];
+    }
+    if (toString.call(cmdArguments[0]) !== '[object Array]') {
+        cmdArguments[0] = [];
+    }
+    cmdArguments[1] = cmdArguments[1] || {};
+    cmdArguments[2] = opts;
+
+    return cmdArguments;
+}
+
+/**
+ * Get bower command instance
+ *
+ * @param {string} cmd bower commands, e.g. 'install' | 'update' | 'cache clean' etc.
+ * @returns {object} bower instance initialised with commands
+ */
+function getBowerCommand(cmd) {
+    // bower has some commands that are provided in a nested object structure, e.g. `bower cache clean`.
+    var bowerCommand;
+
+    // clean up the command given, to avoid unnecessary errors
+    cmd = cmd.trim();
+
+    var nestedCommand = cmd.split(' ');
+
+    if (nestedCommand.length > 1) {
+        // To enable that kind of nested commands, we try to resolve those commands, before passing them to bower.
+        for (var commandPos = 0; commandPos < nestedCommand.length; commandPos++) {
+            if (bowerCommand) {
+                // when the root command is already there, walk into the depth.
+                bowerCommand = bowerCommand[nestedCommand[commandPos]];
+            } else {
+                // the first time we look for the "root" commands available in bower
+                bowerCommand = bower.commands[nestedCommand[commandPos]];
+            }
+        }
+    } else {
+        // if the command isn't nested, just go ahead as usual
+        bowerCommand = bower.commands[cmd];
+    }
+
+    // try to give a good error description to the user when a bad command was passed
+    if (bowerCommand === undefined) {
+        throw new gutil.PluginError(PLUGIN_NAME, 'The command \'' + cmd + '\' is not available in the bower commands');
+    }
+
+    return bowerCommand;
+}
+
+/**
+ * Write stream to filesystem
+ * 
+ * @param {object} opts options object
+ * @param {object} stream file stream
+ */
+function writeStreamToFs(opts, stream) {
+    var baseDir = path.join(opts.cwd, opts.directory);
+    var walker = walk.walk(baseDir);
+
+    walker.on('errors', function (root, stats, next) {
+        stream.emit('error', new gutil.PluginError(PLUGIN_NAME, stats.error));
+        next();
+    });
+    walker.on('directory', function (root, stats, next) {
+        next();
+    });
+
+    walker.on('file', function (root, stats, next) {
+        var filePath = path.resolve(root, stats.name);
+
+        fs.readFile(filePath, function (error, data) {
+            if (error) {
+                stream.emit('error', new gutil.PluginError(PLUGIN_NAME, error));
+            } else {
+                stream.write(new gutil.File({
+                    path: path.relative(baseDir, filePath),
+                    contents: data
+                }));
+            }
+
+            next();
+        });
+    });
+
+    walker.on('end', function () {
+        stream.emit('end');
+    });
+}
+
+module.exports = gulpBower;

--- a/package.json
+++ b/package.json
@@ -1,35 +1,47 @@
 {
-	"name": "gulp-bower",
-	"version": "0.0.11",
-	"description": "Install Bower packages.",
-	"main": "index.js",
-	"dependencies": {
-		"bower": "^1.3.12",
-		"gulp-util": "^3.0.1",
-		"through2": "0.6.2",
-		"walk": "2.3.3"
-	},
-	"devDependencies": {
-		"gulp": "latest",
-		"gulp-jshint": "latest"
-	},
-	"scripts": {
-		"test": "mocha"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/zont/gulp-bower.git"
-	},
-	"keywords": [
-		"gulpplugin",
-		"bower"
-	],
-	"author": "Alexander Zonov <zont@pochta.ru>",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/zont/gulp-bower/issues"
-	},
-	"engines": {
-		"node": ">=0.8"
-	}
+  "name": "gulp-bower",
+  "version": "0.0.11",
+  "description": "Install Bower packages.",
+  "main": "index.js",
+  "dependencies": {
+    "bower": "^1.3.12",
+    "gulp-util": "^3.0.1",
+    "inquirer": "^0.11.2",
+    "through2": "0.6.2",
+    "walk": "2.3.3"
+  },
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "event-stream": "^3.3.2",
+    "gulp": "latest",
+    "gulp-codecov.io": "^1.0.1",
+    "gulp-istanbul": "^0.10.3",
+    "gulp-jshint": "latest",
+    "gulp-mocha": "^2.2.0",
+    "jshint": "^2.9.1",
+    "mocha": "^2.3.4",
+    "rimraf": "^2.5.0",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0",
+    "stream-assert": "^2.0.3"
+  },
+  "scripts": {
+    "test": "node node_modules/gulp/bin/gulp.js post-coverage && node node_modules/gulp/bin/gulp.js lint"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/zont/gulp-bower.git"
+  },
+  "keywords": [
+    "gulpplugin",
+    "bower"
+  ],
+  "author": "Alexander Zonov <zont@pochta.ru>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/zont/gulp-bower/issues"
+  },
+  "engines": {
+    "node": ">=0.8"
+  }
 }

--- a/tests/fileSystemUtils.js
+++ b/tests/fileSystemUtils.js
@@ -1,0 +1,109 @@
+var fs = require('fs');
+var rimraf = require('rimraf');
+
+var BOWERJSON = 'bower.json';
+
+/**
+ * Copy file
+ *
+ * @param {string} src path to source file
+ * @param {string} dest path to destination file
+ * @param {Function} cb done callback
+ */
+function copyFile(source, target, cb) {
+    var cbCalled = false;
+
+    var rd = fs.createReadStream(source);
+    rd.on("error", function (err) {
+        done(err);
+    });
+    var wr = fs.createWriteStream(target);
+    wr.on("error", function (err) {
+        done(err);
+    });
+    wr.on("close", function (ex) {
+        done();
+    });
+    rd.pipe(wr);
+
+    function done(err) {
+        if (typeof cb === "function") {
+            cb(err);
+            cbCalled = true;
+        }
+    }
+}
+
+/**
+ * Write version conflicting bower.json to file
+ * 
+ * @param {Function} done done callback
+ */
+function writeConflictJson(done) {
+    copyFile('./tests/fixtures/bowerConflict.json', BOWERJSON, done);
+}
+
+/**
+ * Write valid bower.json to file
+ * 
+ * @param {Function} done done callback
+ */
+function writeValidJson(done) {
+    copyFile('./tests/fixtures/bowerValid.json', BOWERJSON, done);
+}
+
+/**
+ * Write valid .bowerrc to file
+ * 
+ * @param {Function} done done callback
+ */
+function writeValidBowerrc(done) {
+    copyFile('./tests/fixtures/bowerrcValid.json', './.bowerrc', done);
+}
+
+/**
+ * Write empty .bowerrc to file
+ * 
+ * @param {Function} done done callback
+ */
+function writeEmptyBowerrc(done) {
+    copyFile('./tests/fixtures/bowerrcEmpty.json', './.bowerrc', done);
+}
+
+/**
+ * Delete bower_components
+ *
+ * @param {string} path path to file or directory to delete
+ * @param {Function} done done callback
+ */
+function deletePath(path, done) {
+    rimraf(path, function (err) {
+        if (err) throw (err);
+        if (typeof done === 'function') done();
+    });
+}
+
+/**
+ * Delete bower.json if it exists
+ *
+ * @param {Function} done done callback
+ */
+function deleteBowerJson(done) {
+    fs.stat(BOWERJSON, function (err, stats) {
+        if (err) return done();
+
+        fs.unlink(BOWERJSON, function (err) {
+            if (err) throw err;
+            if (typeof done === 'function') done();
+        });
+    })
+}
+
+module.exports = {
+    writeConflictJson: writeConflictJson,
+    writeValidJson: writeValidJson,
+    writeValidBowerrc: writeValidBowerrc,
+    writeEmptyBowerrc: writeEmptyBowerrc,
+    deletePath: deletePath,
+    deleteBowerJson: deleteBowerJson
+};

--- a/tests/fixtures/bowerConflict.json
+++ b/tests/fixtures/bowerConflict.json
@@ -1,0 +1,27 @@
+{
+    "name": "gulp-bower-test",
+    "description": "Temperary bower.json file for testing",
+    "main": "index.js",
+    "authors": [
+        "Crevil <https://github.com/Crevil>"
+    ],
+    "license": "MIT",
+    "keywords": [
+        "gulp",
+        "gulp-bower"
+    ],
+    "homepage": "git://github.com/zont/gulp-bower.git",
+    "moduleType": [],
+    "private": true,
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "bower_components",
+        "test",
+        "tests"
+    ],
+    "dependencies": {
+        "bootstrap": "~3.3.6",
+        "jquery": "1.8.0"
+    }
+}

--- a/tests/fixtures/bowerValid.json
+++ b/tests/fixtures/bowerValid.json
@@ -1,0 +1,26 @@
+{
+    "name": "gulp-bower-test",
+    "description": "Temperary bower.json file for testing",
+    "main": "index.js",
+    "authors": [
+        "Crevil <https://github.com/Crevil>"
+    ],
+    "license": "MIT",
+    "keywords": [
+        "gulp",
+        "gulp-bower"
+    ],
+    "homepage": "git://github.com/zont/gulp-bower.git",
+    "moduleType": [],
+    "private": true,
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "bower_components",
+        "test",
+        "tests"
+    ],
+    "dependencies": {
+        "log": "0.3.0"
+    }
+}

--- a/tests/fixtures/bowerrcValid.json
+++ b/tests/fixtures/bowerrcValid.json
@@ -1,0 +1,3 @@
+{
+    "directory": "bowerrc_components"
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,256 @@
+/* global describe, xdescribe, it, xit, before, beforeEach, afterEach, after, process */
+/* jshint expr: true */
+
+var streamAssert = require('stream-assert');
+var chai = require('chai');
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+var inquirer = require('inquirer');
+var gutil = require('gulp-util');
+var fs = require('fs');
+
+var fsUtil = require('./fileSystemUtils');
+var bower = require('../index.js');
+
+describe('gulp-bower', function () {
+    var consoleStub;
+    var consoleOutput = '';
+
+    before(function () {
+        chai.use(sinonChai);
+    });
+
+    beforeEach(function (done) {
+        fsUtil.deletePath('bower_components/', function () {
+            fsUtil.deleteBowerJson(function () {
+                fsUtil.deletePath('.bowerrc', done);
+            });
+        });
+
+        // stub gutil.log to suppress output in test results
+        consoleStub = sinon.stub(gutil, 'log', function (val) {
+            consoleOutput += val + '\n';
+        });
+    });
+
+    afterEach(function () {
+        gutil.log.restore();
+    });
+
+    it('should emit error when dependency version can\'t be resolved', function (done) {
+        fsUtil.writeConflictJson(function () {
+            bower()
+                .on('error', function (error) {
+                    try {
+                        expect(error.message).to.match(/resolve.*dependency/);
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                });
+        });
+    });
+
+    it('should pipe files to stream', function (done) {
+        fsUtil.writeValidJson(function () {
+            bower()
+                .pipe(streamAssert.end(done));
+        });
+    });
+
+    describe('option', function () {
+        describe('cmd', function () {
+            it('should throw error on unknown command', function () {
+                var command = 'notValidCommand';
+                expect(function () {
+                    bower({ cmd: command });
+                }).to.throw(/notValidCommand/);
+            });
+
+            it('should handle multi letter commands', function () {
+                var command = 'cache clean';
+                expect(function () {
+                    bower({ cmd: command, verbosity: 2 });
+                }).to.not.throw();
+            });
+        });
+
+        describe('directory', function () {
+            it('should write to default directory', function (done) {
+                fsUtil.writeValidJson(function () {
+                    bower()
+                        .on('end', function () {
+                            fs.stat('bower_components', function (err, stats) {
+                                expect(err).to.not.exist;
+                                done();
+                            });
+                        });
+                });
+            });
+
+            it('should write to explicit directory', function (done) {
+                fsUtil.writeValidJson(function () {
+                    bower({ directory: 'lib' })
+                        .on('end', function () {
+                            fs.stat('lib', function (err, stats) {
+                                expect(err).to.not.exist;
+                                fsUtil.deletePath('lib/', done);
+                            });
+                        });
+                });
+            });
+
+            it('should write to explicit directory from string argument', function (done) {
+                fsUtil.writeValidJson(function () {
+                    bower('lib')
+                        .on('end', function () {
+                            fs.stat('lib', function (err, stats) {
+                                expect(err).to.not.exist;
+                                fsUtil.deletePath('lib/', done);
+                            });
+                        });
+                });
+            });
+
+            it('should use default directory when .bowerrc is empty', function (done) {
+                fsUtil.writeValidJson(function () {
+                    fsUtil.writeEmptyBowerrc(function () {
+                        bower()
+                            .on('end', function () {
+                                fs.stat('bower_components', function (err, stats) {
+                                    expect(err).to.not.exist;
+                                    fsUtil.deletePath('.bowerrc', done);
+                                });
+                            });
+                    });
+                });
+            });
+
+            it('should get directory from .bowerrc', function (done) {
+                fsUtil.writeValidJson(function () {
+                    fsUtil.writeValidBowerrc(function () {
+                        bower()
+                            .on('end', function () {
+                                fs.stat('bowerrc_components', function (err, stats) {
+                                    expect(err).to.not.exist;
+                                    fsUtil.deletePath('bowerrc_components/', function () {
+                                        fsUtil.deletePath('.bowerrc', done);
+                                    });
+                                });
+                            });
+                    });
+                });
+            });
+        });
+
+        describe('interactive', function () {
+            var promptStub;
+            beforeEach(function () {
+                // select first option when prompting
+                promptStub = sinon.stub(inquirer, 'prompt', function (questions, cb) {
+                    setTimeout(function () {
+                        cb({
+                            prompt: '1'
+                        }, 0);
+                    });
+                });
+            });
+
+            afterEach(function () {
+                inquirer.prompt.restore();
+            });
+
+            it('should prompt for action when interactive is true', function (done) {
+                fsUtil.writeConflictJson(function () {
+                    bower({ interactive: true })
+                        .once('end', function () {
+                            try {
+                                expect(promptStub).to.have.been.called;
+                                done();
+                            } catch (err) {
+                                done(err);
+                            }
+                        });
+                });
+            });
+
+            it('should not emit error when dependency version can\'t be resolved and interactive is true', function (done) {
+                fsUtil.writeConflictJson(function () {
+                    var error = false;
+                    bower({ interactive: true })
+                        .once('error', function () {
+                            error = true;
+                        })
+                        .once('end', function () {
+                            try {
+                                expect(error).to.be.false;
+                                done();
+                            } catch (err) {
+                                done(err);
+                            }
+                        });
+                });
+            });
+        });
+
+        describe('verbosity', function () {
+            it('should output nothing when verbosity is 0', function (done) {
+                fsUtil.writeValidJson(function () {
+                    bower({ verbosity: 0 })
+                        .on('end', function () {
+                            try {
+                                expect(consoleStub).to.not.have.been.called;
+                                done();
+                            } catch (err) {
+                                done(err);
+                            }
+                        });
+                });
+            });
+
+            it('should output nothing on errors when verbosity is 0', function (done) {
+                fsUtil.writeConflictJson(function () {
+                    bower({ verbosity: 0 })
+                        .on('error', function () {
+                            try {
+                                expect(consoleStub).to.not.have.been.called;
+                                done();
+                            } catch (err) {
+                                done(err);
+                            }
+                        });
+                });
+            });
+
+            it('should output errors when verbosity is 1', function (done) {
+                fsUtil.writeConflictJson(function () {
+                    bower({ verbosity: 1 })
+                        .on('error', function () {
+                            try {
+                                expect(consoleStub).to.have.been.called;
+                                done();
+                            } catch (err) {
+                                done(err);
+                            }
+                        });
+                });
+            });
+
+            it('should output info when verbosity is 2', function (done) {
+                fsUtil.writeValidJson(function () {
+                    bower({ verbosity: 2 })
+                        .on('end', function () {
+                            try {
+                                expect(consoleStub).to.have.been.called;
+                                done();
+                            } catch (err) {
+                                done(err);
+                            }
+                        });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR add a lot of functionality and refactores the plugin.
# Refactoring
I've taken the freedom to refactor the plugin to smaller methods instead of one large one. This makes to code more readable.

# Verbosity option
As requested in #34 the ability to keep the plugin quiet could be nice. 
I've implemented the verbosity option with three levels.
* 1: no log
* 2: error log
* 3: info (default as it is now)

# Prompting / interactive
When a dependency cannot be resolved the plugin throws an error. As suggested in #35 this is due to the missing catch of event `prompt`. 
I've implemented this and set an `interactive` option to enable user interaction. If set to `false` (default) it throws an error and print en error message. If `true`, the user may select the prober version.
A short coming of this: It is not possible to output the options directly. By having `verbosity` level 3 the bower output will display where to conflict arrises.

# .bowerrc handling
Implement catch on empty `.bowerrc` file as mentioned in #43.
If the JSON is not valid or the directory property is not set, use default directory (`bower_components`).

# Tests
To help me and other developers to work on the plugin I've implemented tests written in mocha with chai.  It runs on the gulp task `gulp test`. There is coverage included in this as well.
Further more I've setup [travis](https://travis-ci.org/Crevil/gulp-bower) to run the tests. It uses the `npm test`command which in turn runs `gulp post-coverage`and `gulp lint`. This posts coverage results to [codecov.io](https://codecov.io/github/Crevil/gulp-bower).
When merging this PR the travis setup must be done on this repository. No setup is required on codecov.

# API
I've added a section in the readme with a condensed API description for the available options.