### PR TITLE
Add incompatible log for dependency pick list

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,6 @@ function incompatibleLog(logdata) {
     // Generate dependants string for each pick
     logdata.picks.forEach(function (pick) {
         pick.dependants = pick.dependants.map(function (dependant) {
-            console.log(dependant);
             var release = dependant.pkgMeta._release;
             return dependant.endpoint.name + (release ? '#' + release : '');
         }).join(', ');


### PR DESCRIPTION
With interactive set to true the user is presented with a prompt to specify a dependency when incompatibilities are found. This change logs the possible choices before the prompt.