### PR TITLE
emit 'finish' event on end (compatibility with Gulp@^4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,6 +242,7 @@ function writeStreamToFs(opts, stream) {
 
     walker.on('end', function () {
         stream.emit('end');
+        stream.emit('finish');
     });
 }
 


### PR DESCRIPTION
Gulp 4 only recognizes stream tasks as completed when they emit a "finish" event. Otherwise it will print "task  <task> did not complete"